### PR TITLE
Add Eta Kappa Nu to navbar.

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -31,6 +31,8 @@
             %a{href: url_for(:ieee, :index)} IEEE
           %li
             %a{href: url_for(:hacsoc, :index)} HacSoc
+          %li
+            %a{href: 'https://hkn.case.edu'} HKN
         %span.brace } @ CWRU
     .container
       =yield


### PR DESCRIPTION
Hey ACM/HacSoc!  I'm the "webmaster" for Eta Kappa Nu, CWRU's EECS honor society.  Aaron was really helpful at the end of last year and the beginning of this year for getting HKN some hosting through ACM.  One of the possibilities that we at HKN have been hoping for is having our site integrate with the rest of the ACM's sites, as we'd like to consider ourselves part of Case's EECS student ecosystem.  We've got a site set up over at [hkn.case.edu](https://hkn.case.edu) that fits in well with the ACM site.  It has basic info about HKN, as well as our budding pet projects: a professor-approved exam archive (powered by student submissions) and a question answering service (anything from advising to homework).

This pull requests adds a link to the navbar for HKN, making the integration between our two sites pretty much seamless.
