### PR TITLE
Add links to our GitHub organizations

### DIFF
--- a/app/views/acm/index.haml
+++ b/app/views/acm/index.haml
@@ -37,6 +37,14 @@
   you are interested in being involved in one of these projects (even if you
   aren't a Computer Science major), drop the project leader an e-mail!*
 
+#github
+%h2 GitHub Organizations
+:markdown
+  We have two GitHub organizations where members can contribute to the code that
+  helps run Hacker Society. You can find us at
+  [hacsoc](https://github.com/hacsoc/) and
+  [cwruacm](https://github.com/cwruacm/).
+
 #conference
 %h2
   %a{href: url_for('acm/conference')} ACM Conference: Link-State

--- a/app/views/acm/index.haml
+++ b/app/views/acm/index.haml
@@ -38,12 +38,11 @@
   aren't a Computer Science major), drop the project leader an e-mail!*
 
 #github
-%h2 GitHub Organizations
+%h2 [GitHub Organization](https://github.com/hacsoc/)
 :markdown
-  We have two GitHub organizations where members can contribute to the code that
-  helps run Hacker Society. You can find us at
-  [hacsoc](https://github.com/hacsoc/) and
-  [cwruacm](https://github.com/cwruacm/).
+  We have our GitHub organization where members can view and contribute to the
+  code that helps run Hacker Society. You can find us at
+  [hacsoc](https://github.com/hacsoc/).
 
 #conference
 %h2


### PR DESCRIPTION
Now the homepage has links to https://github.com/cwruacm/ and https://github.com/hacsoc/.