### PR TITLE
Explicitly use ruby:2.2.3-onbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:onbuild
+FROM ruby:2.2.3-onbuild
 
 WORKDIR /usr/src/app
 CMD ["unicorn","-d","-c", "unicorn.conf"]


### PR DESCRIPTION
So we don't run unto errors when ruby:onbuild updates to the latest version before we're ready