### PR TITLE
remove old registration iframe

### DIFF
--- a/app/views/acm/conference/2014.haml
+++ b/app/views/acm/conference/2014.haml
@@ -28,18 +28,11 @@
 
 %ul.toci
   %li
-    %a{href: '#register'} Register
-  %li
     %a{href: '#sponsors'} Sponsors
   %li
     %a{href: '#schedule'} Schedule 
   %li
     %a{href: '#speakers'} Speakers
-
-#register
-  %h2 Register
-  %iframe{:width => '100%', :height => '300', :frameborder => '0', :src => 'http://www.eventbrite.com/tickets-external?eid=12500710963&ref=etckt&v=2', :target => 'HTML' }
-    %img{ :border => '0',  :src =>'http://www.eventbrite.com/custombutton?eid=12500710963', :alt =>'Register for ACM Link-State'}
 
 #sponsors
   %h2 Sponsors


### PR DESCRIPTION
Having a iframe to show "this event no longer exists" is not great.