### PR TITLE
Adding some breaks to make the info sidebar narrower

### DIFF
--- a/app/views/acm/conference/2015.haml
+++ b/app/views/acm/conference/2015.haml
@@ -14,7 +14,11 @@
       .value TBD, ca. 10:00AM-7:00PM
       %span.key Location:
       .value
-        %a{:href => 'http://goo.gl/xsJQRd'} Hovorka Atrium, Agnar Pytte Science Center, Case Western Reserve University
+        %a{:href => 'http://goo.gl/xsJQRd'} Hovorka Atrium
+        %br
+        Agnar Pytte Science Center
+        %br
+        Case Western Reserve University
       %span.key Contact:
       .value
         #{mail_to "trm70@case.edu", "Thomas Murphy"}


### PR DESCRIPTION
By breaking up the `Hovorka Atrium, Agnar Pytte Science Center, Case Western Reserve University` line, the info sidebar becomes narrower and gives more space for the `h1` title on the page. Better formatting, at least somewhat.