### PR TITLE
Adding CWRU Robotics cosponsorship to Rise Robotics and NASA GVIS

### DIFF
--- a/config/speakers.yml
+++ b/config/speakers.yml
@@ -104,6 +104,8 @@ speakers_2015:
        Arron Acosta is the CEO at Rise Robotics where he leads by following
        first.
 
+       This talk is presented in a cosponsorship with the CWRU Robotics Team.
+
   - name: Maha Achour
     affiliation: Polyceed Inc.
     title: 'From Fundamental Research to Successful Commercialization: Steps, Risk, and Challenges'
@@ -174,6 +176,8 @@ speakers_2015:
       the GVIS Lab and include demonstrations.
 
        Speaker biographies coming soon.
+
+       This talk is presented in a cosponsorship with the CWRU Robotics Team.
 
   - name: Charlotte Chang & Nicole Capuana
     affiliation: LeanDog


### PR DESCRIPTION
We worked with the CWRU Robotics team to bring these speakers to Link-State. This is giving that team credit for providing their resources and contacts to improve and complete the conference.