### PR TITLE
Officers 2016, activate!

### DIFF
--- a/app/views/acm/index.haml
+++ b/app/views/acm/index.haml
@@ -3,19 +3,19 @@
   %h2 Contact Us
   %ul.aside-list
     %li
-      %a.key{ href: 'mailto:amg188@case.edu' } Adam Gleichsner
+      %a.key{ href: 'mailto:acv31@case.edu' } Anno van den Akker
       .value President
     %li
-      %a.key{ href: 'mailto:ajm188@case.edu' } Andrew Mason
+      %a.key{ href: 'mailto:mtb89@case.edu' } Matthew Bentley
       .value Vice President of ACM
     %li
-      %a.key{ href: 'mailto:zwh2@case.edu' } Zachary Hudson
+      %a.key{ href: 'mailto:mlm232@case.edu' } Morgan McMahon
       .value Vice President of IEEE
     %li
-      %a.key{ href: 'mailto:acv31@case.edu' } Anno van den Akker
+      %a.key{ href: 'mailto:lak98@case.edu' } Leah Karasek
       .value Treasurer
     %li
-      %a.key{ href: 'mailto:trm70@case.edu' } Thomas Murphy
+      %a.key{ href: 'mailto:dcl71@case.edu' } David Lance
       .value Secretary
     %li
       %a.key{ href: 'mailto:krc53@case.edu' } Katherine Cass

--- a/app/views/acm/index.haml
+++ b/app/views/acm/index.haml
@@ -7,10 +7,10 @@
       .value President
     %li
       %a.key{ href: 'mailto:mtb89@case.edu' } Matthew Bentley
-      .value Vice President of ACM
+      .value VP of ACM
     %li
       %a.key{ href: 'mailto:mlm232@case.edu' } Morgan McMahon
-      .value Vice President of IEEE
+      .value VP of IEEE
     %li
       %a.key{ href: 'mailto:lak98@case.edu' } Leah Karasek
       .value Treasurer


### PR DESCRIPTION
A second set of eyes to make sure I botched no spellings or Case IDs wouldn't hurt.  

There is one concern however... Morgan and Matthew's names are long enough to make this happen:

![acmofficers](https://cloud.githubusercontent.com/assets/5682515/11758080/d4a221ec-a034-11e5-8e2f-a87e87bc5938.png)

I can either abbreviate "Vice President" to VP, or increase the `min-width` of the `aside-list` slightly, which seems to have no major affect on the rest of the site.  PR reviewer's choice!