### PR TITLE
Update meta tag in 2016 page.

### DIFF
--- a/app/views/acm/conference/2016.haml
+++ b/app/views/acm/conference/2016.haml
@@ -1,7 +1,7 @@
 #{meta_tag "summary", :name => "twitter:card"}
 #{meta_tag "@cwruacm", :name => "twitter:site"}
 #{meta_tag "EECS @ CWRU -- Link-State 2016 Conference", :name => "twitter:title"}
-#{meta_tag "The fourth annual student-run tech conference at Case Western Reserve University taking place all day on Saturday October 3rd, 2015.", :name => "twitter:description"}
+#{meta_tag "The fifth annual student-run tech conference at Case Western Reserve University taking place all day on Saturday October 8th, 2016.", :name => "twitter:description"}
 #{meta_tag "http://acm.case.edu" + "#{image_path 'LinkState175px.png'}", :name => "twitter:image"}
 %aside.right
   = image_tag 'LinkState175px.png'


### PR DESCRIPTION
Noticed a bug in the "description" that Slack posted when you send this link.  I just adjusted it to be up-to-date for 2016.